### PR TITLE
Allow failures due to lock contention fail successfully

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,16 +34,7 @@ log and return exit code of the command.`,
 		}
 
 		if err := e.Run(tableName, keyName, shellCommand, sleepStartRandom, holdLockBy); err != nil {
-			// dynamolock.LockNotGrantedError doesn't export the error so this is the next best we can do.
-			// This is obviously super fragile (i.e if the error msg wording is updated, this fails)
-			lockFailedErr := "Didn't acquire lock because it is locked and request is configured not to retry."
-
-			// Don't consider errors due to lock contention as failures
-			if err.Error() == lockFailedErr {
-				logrus.Warning(err)
-			} else {
-				logrus.Fatal(err)
-			}
+			logrus.Fatal(err)
 		}
 	},
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,7 +34,16 @@ log and return exit code of the command.`,
 		}
 
 		if err := e.Run(tableName, keyName, shellCommand, sleepStartRandom, holdLockBy); err != nil {
-			logrus.Fatal(err)
+			// dynamolock.LockNotGrantedError doesn't export the error so this is the next best we can do.
+			// This is obviously super fragile (i.e if the error msg wording is updated, this fails)
+			lockFailedErr := "Didn't acquire lock because it is locked and request is configured not to retry."
+
+			// Don't consider errors due to lock contention as failures
+			if err.Error() == lockFailedErr {
+				logrus.Warning(err)
+			} else {
+				logrus.Fatal(err)
+			}
 		}
 	},
 }

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -68,15 +68,12 @@ func (d *Exec) Run(tableName string, keyName string, command string, sleepStartR
 		dynamolock.FailIfLocked(),
 	)
 	if err != nil {
-		// dynamolock.LockNotGrantedError doesn't export the error so this is the next best thing we can do.
-		// This is obviously super fragile (i.e if the error msg wording is updated, this fails)
-		lockFailedErr := "Didn't acquire lock because it is locked and request is configured not to retry."
-		if err.Error() != lockFailedErr {
+		if _, ok := err.(*dynamolock.LockNotGrantedError); !ok {
 			return err
 		}
 
 		// We still want to exit early, just not as an error.
-		logrus.Warning(lockFailedErr)
+		logrus.Warning(err)
 		return nil
 	}
 	logrus.Info("Lock acquired")

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -68,7 +68,16 @@ func (d *Exec) Run(tableName string, keyName string, command string, sleepStartR
 		dynamolock.FailIfLocked(),
 	)
 	if err != nil {
-		return err
+		// dynamolock.LockNotGrantedError doesn't export the error so this is the next best thing we can do.
+		// This is obviously super fragile (i.e if the error msg wording is updated, this fails)
+		lockFailedErr := "Didn't acquire lock because it is locked and request is configured not to retry."
+		if err.Error() != lockFailedErr {
+			return err
+		}
+
+		// We still want to exit early, just not as an error.
+		logrus.Warning(lockFailedErr)
+		return nil
 	}
 	logrus.Info("Lock acquired")
 

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -72,7 +72,7 @@ func (d *Exec) Run(tableName string, keyName string, command string, sleepStartR
 			return err
 		}
 
-		// We still want to exit early, just not as an error.
+		// Exit early, just not as an error.
 		logrus.Warning(err)
 		return nil
 	}

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -76,19 +76,19 @@ func (d *Exec) Run(tableName string, keyName string, command string, sleepStartR
 	logrus.WithFields(logrus.Fields{
 		"command": command,
 	}).Info("Executing command")
-	out, err := runExec(command)
+	out, cmdErr := runExec(command)
+
+	// Remove the trailing newline (and any other extraneous whitespace)
+	// so they don't pollute the log output.
+	trimedOutput := strings.TrimSpace(out)
 
 	// Always print output, regardless of error
-	lines := strings.Split(out, "\n")
+	lines := strings.Split(trimedOutput, "\n")
 	for _, l := range lines {
 		logrus.WithFields(logrus.Fields{
 			"command": command,
 			"line":    l,
 		}).Info("Command output")
-	}
-
-	if err != nil {
-		return err
 	}
 
 	if holdLockBy > 0 {
@@ -105,7 +105,9 @@ func (d *Exec) Run(tableName string, keyName string, command string, sleepStartR
 	}
 	logrus.Info("Lock released")
 
-	return nil
+	// If there were no locking errors,
+	// fallback to returning the error from the command.
+	return cmdErr
 }
 
 // RunCommand executes the command.


### PR DESCRIPTION
This will enable tracking actual errors like failed commands or other
misc dynamodb errors. Lock contention is an expected behavior and we
shouldn't be treating those as errors.

I also updated the `Run` function to always fallback to returning the
error from the command execution and not exiting early.

I also stuck in a strings.TrimSpace.