### PR TITLE
key is a reserved word and must be an attribute

### DIFF
--- a/lock/lock.go
+++ b/lock/lock.go
@@ -21,7 +21,10 @@ func (c *Client) Lock(ctx context.Context, key string, expire time.Duration) err
 	_, err := c.storage.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(c.table),
 
-		ConditionExpression: aws.String("attribute_not_exists(key) OR expire < :now"),
+		ConditionExpression: aws.String("attribute_not_exists(#key) OR expire < :now"),
+		ExpressionAttributeNames: map[string]string{
+			"#key": "key",
+		},
 		ExpressionAttributeValues: map[string]types.AttributeValue{
 			":now": &types.AttributeValueMemberN{Value: strconv.Itoa(int(now))},
 		},


### PR DESCRIPTION
Last minute I switched from using `id` to using `key` as the primary key because it makes more sense and maintains compatibility with the existing db. But turns out `key` is a reserved word in dynamodb so in order to use it we have to proxy it through an attribute name.