### PR TITLE
Add log passthrough for lock-exec

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,17 +20,17 @@ func (c *cli) newRunCmd() *cobra.Command {
 			locker := c.newLocker()
 
 			log.Info("running command")
-			out, err := locker.Run(c.cmd.Context(), args[0], args[1])
+			err := locker.Run(c.cmd.Context(), args[0], args[1])
 			if err != nil {
 				if errors.Is(err, lock.ErrLocked) {
 					log.Info("did not run command. key is locked")
 					return
 				}
 
-				log.Fatalw("command failed", "error", err, "output", out)
+				log.Fatalw("command failed", "error", err)
 			}
 
-			log.Infow("command succeeded", "output", out)
+			log.Infow("command succeeded")
 		},
 	}
 

--- a/lock/run_test.go
+++ b/lock/run_test.go
@@ -18,20 +18,17 @@ func TestRun(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		out, err := tc.Run(ctx, "locktest", "sleep 1")
-		assert.Empty(t, out)
+		err := tc.Run(ctx, "locktest", "sleep 1")
 		assert.NoError(t, err)
 		wg.Done()
 	}()
 	time.Sleep(time.Millisecond * 500)
 
-	out, err := tc.Run(ctx, "locktest", "sleep 5")
-	assert.Empty(t, out)
+	err := tc.Run(ctx, "locktest", "sleep 5")
 	assert.ErrorIs(t, err, ErrLocked)
 
-	out, err = tc.Run(ctx, "locktest", "echo hello test")
+	err = tc.Run(ctx, "locktest", "echo hello test")
 	assert.NoError(t, err)
-	assert.Equal(t, "hello test", out)
 
 	wg.Wait()
 }


### PR DESCRIPTION
Writes command output directly to std IO and no longer returns a buffer.

https://www.loom.com/share/fc29e6dce02e43059e495169468caf0e