### PR TITLE
WIP: Add Support for "Global" Locks

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -24,6 +24,7 @@ type cli struct {
 
 	table   string
 	expire  time.Duration
+	global  bool
 	version string
 }
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -8,10 +8,17 @@ import (
 
 // newLocker returns a new lock client or logs and exits on failure.
 func (c *cli) newLocker() *lock.Client {
-	cfg, err := config.LoadDefaultConfig(c.cmd.Context())
+	table, options := c.table, [](func(*config.LoadOptions) error)(nil) // table, no options
+
+	// override table and region if global flag is set
+	if c.global {
+		table, options = globalTable, append(options, config.WithRegion(globalRegion))
+	}
+
+	cfg, err := config.LoadDefaultConfig(c.cmd.Context(), options...)
 	c.fatalErr(err, "failed to load aws config")
 
-	return lock.New(dynamodb.NewFromConfig(cfg), c.table)
+	return lock.New(dynamodb.NewFromConfig(cfg), table)
 }
 
 // fatalErr logs the message and error and then exits if the error is not nil.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,15 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	globalRegion = "us-west-2"
+	globalTable  = "lock-exec-global"
 )
 
 // newRootCmd creates our base cobra command to add all subcommands to.
@@ -18,6 +24,7 @@ func (c *cli) newRootCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&c.table, "table", "t", "lock-exec", "table name in dynamodb to use for locking")
 	cmd.PersistentFlags().DurationVarP(&c.expire, "expire", "e", time.Hour*24, "lock duration in the event that the post-run unlock fails") //nolint:mnd
+	cmd.PersistentFlags().BoolVarP(&c.global, "global", "g", false, fmt.Sprintf("creates lock in global region %s with global table %s", globalRegion, globalTable))
 
 	cmd.AddCommand(
 		c.newRunCmd(),


### PR DESCRIPTION
- Adds support for adding in global locks with the `-g, --global` flag
- This forces creating the lock in the `us-west-2` region with the `lock-exec-global` table
- The `lock-exec-global` does not exist yet