### PR TITLE
INF-873: Add Override Region Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 You must already be authenticated to AWS with a default region. `lock-exec` uses [`config.LoadDefaultConfig`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/config#LoadDefaultConfig) to load AWS credentials using the standard credential chain and does not currently support any direct method of authentication.
 
-Additionally, `lock-exec` requires a dynamodb table to use for locking. This table must have a partition key named `key` that stores the lock keys. The default table name is `lock-exec`. If you use a different table name you must specify it explictly using the `--table` flag.
+Additionally, `lock-exec` requires a dynamodb table to use for locking. This table must have a partition key named `key` that stores the lock keys. The default table name is `lock-exec`. If you use a different table name you must specify it explictly using the `--table` flag. It is also possible to override the default AWS region using the `--region` flag.
 
 ### Required IAM Permissions
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -22,6 +22,7 @@ type cli struct {
 	cmd *cobra.Command
 	log *zap.SugaredLogger
 
+	region  string
 	table   string
 	expire  time.Duration
 	version string

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -8,7 +8,12 @@ import (
 
 // newLocker returns a new lock client or logs and exits on failure.
 func (c *cli) newLocker() *lock.Client {
-	cfg, err := config.LoadDefaultConfig(c.cmd.Context())
+	options := [](func(*config.LoadOptions) error)(nil)
+	if r := c.region; r != "" {
+		options = append(options, config.WithRegion(r))
+	}
+
+	cfg, err := config.LoadDefaultConfig(c.cmd.Context(), options...)
 	c.fatalErr(err, "failed to load aws config")
 
 	return lock.New(dynamodb.NewFromConfig(cfg), c.table)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ func (c *cli) newRootCmd() *cobra.Command {
 		DisableAutoGenTag: true,
 	}
 
+	cmd.PersistentFlags().StringVarP(&c.region, "region", "r", "", "override region to use for dynamodb table")
 	cmd.PersistentFlags().StringVarP(&c.table, "table", "t", "lock-exec", "table name in dynamodb to use for locking")
 	cmd.PersistentFlags().DurationVarP(&c.expire, "expire", "e", time.Hour*24, "lock duration in the event that the post-run unlock fails") //nolint:mnd
 


### PR DESCRIPTION
- Add `-r, --region` flag to override default region used for dynamodb locking table