### PR TITLE
Upgrade Go Module to v2

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/loomhq/lock-exec/lock"
+	"github.com/loomhq/lock-exec/v2/lock"
 )
 
 // newLocker returns a new lock client or logs and exits on failure.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"errors"
 
-	"github.com/loomhq/lock-exec/lock"
+	"github.com/loomhq/lock-exec/v2/lock"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/loomhq/lock-exec
+module github.com/loomhq/lock-exec/v2
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/loomhq/lock-exec/cmd"
+	"github.com/loomhq/lock-exec/v2/cmd"
 )
 
 // version is populated at build time by goreleaser.


### PR DESCRIPTION
- Allow go get to pull v2.x.x versions of module by adding /v2 suffix
- https://go.dev/ref/mod#major-version-suffixes